### PR TITLE
Standardize CI (tier: important)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ jobs:
   R-CMD-check:
     uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
     with:
-      tier: unimportant
+      tier: important
       jags: false
       tex: false
       private: false


### PR DESCRIPTION
Closes #16.

Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **important**, private=false, jags=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers unchanged.